### PR TITLE
Fix docker-publish.yaml

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -65,7 +65,7 @@ jobs:
     needs: build-and-push-image
     steps:
       - name: Set up image tag
-        run: echo "IMAGE_TAG=ghcr.io/oneliberty/moonlight-chrome-tizen:${{ github.ref_name }}" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG=ghcr.io/toypoodlegaming/moonlight-chrome-tizen:${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Run Docker container
         run: docker run -d --name temp_container $IMAGE_TAG


### PR DESCRIPTION
replace ghcr.io/oneliberty by ghcr.io/toypoodlegaming so that it publishes your Moonlight.wgt version in the release section instead of oneliberty's version.

By the way, people can directly use the Tizen IDE to install app with certificates (no need for CLI), but just importing Moonlight.wgt in the IDE and using "Run As -> Tizen Web App", after remotely connected to TV in dev mode in the IDE